### PR TITLE
Fix PHP 8.2 deprecations.

### DIFF
--- a/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/Symphony.php
@@ -1638,7 +1638,7 @@ class Symphony extends AbstractBase implements LoggerAwareInterface
     protected function getPolicyList($policyType)
     {
         try {
-            $cacheKey = 'symphony' . hash('sha256', "${policyType}");
+            $cacheKey = 'symphony' . hash('sha256', "{$policyType}");
 
             if (isset($this->policies[$policyType])) {
                 return $this->policies[$policyType];

--- a/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
+++ b/module/VuFind/src/VuFind/ILS/Driver/VoyagerRestful.php
@@ -1829,7 +1829,7 @@ class VoyagerRestful extends Voyager implements
         ];
 
         $sql = $this->buildSqlFromArray($sqlArray);
-        $outersql = "select count(avail.item_id) CNT from (${sql['string']}) avail" .
+        $outersql = "select count(avail.item_id) CNT from ({$sql['string']}) avail" .
             ' where avail.STATUS=1'; // 1 = not charged
 
         try {

--- a/module/VuFind/src/VuFind/OAuth2/Entity/AccessTokenEntity.php
+++ b/module/VuFind/src/VuFind/OAuth2/Entity/AccessTokenEntity.php
@@ -54,6 +54,7 @@ class AccessTokenEntity implements AccessTokenEntityInterface, \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $properties = [

--- a/module/VuFind/src/VuFind/OAuth2/Entity/AuthCodeEntity.php
+++ b/module/VuFind/src/VuFind/OAuth2/Entity/AuthCodeEntity.php
@@ -54,6 +54,7 @@ class AuthCodeEntity implements AuthCodeEntityInterface, \JsonSerializable
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $properties = [

--- a/module/VuFind/src/VuFind/OAuth2/Entity/RefreshTokenEntity.php
+++ b/module/VuFind/src/VuFind/OAuth2/Entity/RefreshTokenEntity.php
@@ -52,6 +52,7 @@ class RefreshTokenEntity implements RefreshTokenEntityInterface, \JsonSerializab
      *
      * @return string
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $properties = [

--- a/module/VuFind/src/VuFind/Search/Blender/Params.php
+++ b/module/VuFind/src/VuFind/Search/Blender/Params.php
@@ -493,7 +493,7 @@ class Params extends \VuFind\Search\Solr\Params
      */
     protected function proxyMethod(string $method, array $params)
     {
-        $result = call_user_func_array(['parent', $method], $params);
+        $result = call_user_func_array(parent::class . "::$method", $params);
         foreach ($this->searchParams as $searchParams) {
             $result = call_user_func_array([$searchParams, $method], $params);
         }

--- a/module/VuFind/src/VuFind/Search/QueryAdapter.php
+++ b/module/VuFind/src/VuFind/Search/QueryAdapter.php
@@ -69,7 +69,7 @@ abstract class QueryAdapter
             $operator = $search['g'][0]['b'];
             return new QueryGroup(
                 $operator,
-                array_map(['self', 'deminify'], $search['g'])
+                array_map(self::class . '::deminify', $search['g'])
             );
         } else {
             // Special case: The outer-most group-of-groups.
@@ -77,7 +77,7 @@ abstract class QueryAdapter
                 $operator = $search[0]['j'];
                 return new QueryGroup(
                     $operator,
-                    array_map(['self', 'deminify'], $search)
+                    array_map(self::class . '::deminify', $search)
                 );
             } else {
                 // Simple query

--- a/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
+++ b/module/VuFind/tests/unit-tests/src/VuFindTest/View/Helper/Root/CookieConsentTest.php
@@ -190,11 +190,27 @@ class CookieConsentTest extends \PHPUnit\Framework\TestCase
             ->will($this->returnValue('http://localhost/first/vufind'));
         $serverUrl = new ServerUrl();
         $serverUrl->setHost('localhost');
-        $layout = $this->getMockBuilder(Layout::class)->getMock();
-        $layout->expects($this->any())
-            ->method('__invoke')
-            ->will($this->returnValue($layout));
-        $layout->rtl = false;
+
+        // Create an anonymous class to stub out some behavior:
+        $layout = new class () {
+            public $rtl = false;
+
+            /**
+             * Set layout template or retrieve "layout" view model
+             *
+             * If no arguments are given, grabs the "root" or "layout" view model.
+             * Otherwise, attempts to set the template for that view model.
+             *
+             * @param null|string $template Template
+             *
+             * @return Model|null|self
+             */
+            public function __invoke($template = null)
+            {
+                return $this;
+            }
+        };
+
         $plugins = [
             'escapeHtmlAttr' => new EscapeHtmlAttr(),
             'layout' => $layout,

--- a/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
+++ b/module/VuFindTheme/tests/unit-tests/src/VuFindTest/CssPreCompilerTest.php
@@ -78,7 +78,7 @@ class CssPreCompilerTest extends \PHPUnit\Framework\TestCase
     protected static function makeFakeThemeStructure($ext)
     {
         $temp = sys_get_temp_dir();
-        $testDest = $temp . "/vufind_${ext}_comp_test/";
+        $testDest = $temp . "/vufind_{$ext}_comp_test/";
         // Create directory structure, recursively
         mkdir($testDest . "themes/child/$ext", 0777, true);
         mkdir($testDest . 'themes/empty', 0777, true);


### PR DESCRIPTION
With these fixes the remaining deprecation notices during unit tests are from external dependencies. Also `PHP_CS_FIXER_IGNORE_ENV=1 composer qa` passes.