### PR TITLE
Fix getLastLogin/setLastLogin.

### DIFF
--- a/module/VuFind/src/VuFind/Db/Entity/User.php
+++ b/module/VuFind/src/VuFind/Db/Entity/User.php
@@ -666,24 +666,24 @@ class User implements UserEntityInterface
     /**
      * Last login setter.
      *
-     * @param DateTime $dateTime Last login date
+     * @param ?DateTime $dateTime Last login date
      *
      * @return static
      */
-    public function setLastLogin(DateTime $dateTime): static
+    public function setLastLogin(?DateTime $dateTime): static
     {
-        $this->lastLogin = $dateTime;
+        $this->lastLogin = $this->getNonNullableDateTimeFromNullable($dateTime);
         return $this;
     }
 
     /**
      * Last login getter
      *
-     * @return DateTime
+     * @return ?DateTime
      */
-    public function getLastLogin(): DateTime
+    public function getLastLogin(): ?DateTime
     {
-        return $this->lastLogin;
+        return $this->getNullableDateTimeFromNonNullable($this->lastLogin);
     }
 
     /**

--- a/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
+++ b/module/VuFind/src/VuFind/Db/Entity/UserEntityInterface.php
@@ -344,18 +344,18 @@ interface UserEntityInterface extends
     /**
      * Last login setter.
      *
-     * @param DateTime $dateTime Last login date
+     * @param ?DateTime $dateTime Last login date
      *
      * @return static
      */
-    public function setLastLogin(DateTime $dateTime): static;
+    public function setLastLogin(?DateTime $dateTime): static;
 
     /**
      * Last login getter
      *
-     * @return DateTime
+     * @return ?DateTime
      */
-    public function getLastLogin(): DateTime;
+    public function getLastLogin(): ?DateTime;
 
     /**
      * Created setter


### PR DESCRIPTION
While working on audit events I noticed that getLastLogin/setLastLogin doesn't allow null, but it should. I thought this would be a good place to get it sorted.