### PR TITLE
Add PersistenceManagerFactory::getEntityManager()

### DIFF
--- a/module/VuFind/src/VuFind/Db/PersistenceManager.php
+++ b/module/VuFind/src/VuFind/Db/PersistenceManager.php
@@ -29,7 +29,7 @@
 
 namespace VuFind\Db;
 
-use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityManagerInterface;
 use VuFind\Auth\UserSessionPersistenceInterface;
 use VuFind\Db\Entity\EntityInterface;
 use VuFind\Db\Entity\UserEntityInterface;
@@ -53,11 +53,11 @@ class PersistenceManager implements DbServiceAwareInterface
     /**
      * Constructor
      *
-     * @param EntityManager $entityManager Doctrine ORM entity manager
-     * @param bool          $privacy       Is user privacy mode enabled?
+     * @param EntityManagerInterface $entityManager Doctrine ORM entity manager
+     * @param bool                   $privacy       Is user privacy mode enabled?
      */
     public function __construct(
-        protected EntityManager $entityManager,
+        protected EntityManagerInterface $entityManager,
         protected bool $privacy = false
     ) {
     }

--- a/module/VuFind/src/VuFind/Db/PersistenceManagerFactory.php
+++ b/module/VuFind/src/VuFind/Db/PersistenceManagerFactory.php
@@ -29,6 +29,7 @@
 
 namespace VuFind\Db;
 
+use Doctrine\ORM\EntityManagerInterface;
 use Laminas\ServiceManager\Exception\ServiceNotCreatedException;
 use Laminas\ServiceManager\Exception\ServiceNotFoundException;
 use Laminas\ServiceManager\Factory\FactoryInterface;
@@ -67,9 +68,21 @@ class PersistenceManagerFactory implements FactoryInterface
     ) {
         $config = $container->get(\VuFind\Config\PluginManager::class)->get('config');
         return new $requestedName(
-            $container->get('doctrine.entitymanager.orm_vufind'),
+            $this->getEntityManager($container),
             (bool)($config->Authentication->privacy ?? false),
             ...($options ?? [])
         );
+    }
+
+    /**
+     * Get entity manager to be passed to the constructor.
+     *
+     * @param ContainerInterface $container Service manager
+     *
+     * @return EntityManagerInterface
+     */
+    protected function getEntityManager(ContainerInterface $container): EntityManagerInterface
+    {
+        return $container->get('doctrine.entitymanager.orm_vufind');
     }
 }


### PR DESCRIPTION
Our admin interface uses another database in addition to the VuFind database. This allows to use the same functionality by extending from `PersistenceManagerFactory`.